### PR TITLE
Upgrade bedrock-zcap-storage to ^1.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bedrock-mongodb": "^5.5.0",
     "bedrock-package-manager": "^1.0.0",
     "bedrock-security-context": "^1.0.0",
-    "bedrock-zcap-storage": "digitalbazaar/bedrock-zcap-storage#initial"
+    "bedrock-zcap-storage": "^1.0.0"
   },
   "directories": {
     "lib": "./lib"


### PR DESCRIPTION
New dependencies day! 

Also noticing that this is a dependency of this project
which in turn is a dependency of:

https://github.com/digitalbazaar/bedrock-kms-http/blob/use-keystores/package.json

so it is a bit redundant.