### PR TITLE
Fix deps

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,6 @@
 'use strict';
 
 const bedrock = require('bedrock');
-const base58 = require('bs58');
 const {documentLoader} = require('bedrock-jsonld-document-loader');
 const jsigs = require('jsonld-signatures');
 const didKeyDriver = require('did-method-key').driver();
@@ -88,11 +87,3 @@ exports.runOperation = async ({
 };
 
 exports.defaultDocumentLoader = defaultDocumentLoader;
-
-function parsePublicKeyBase58(didKeyUrl) {
-  const fingerprint = didKeyUrl.substr('did:key:'.length);
-  // skip leading `z` that indicates base58 encoding
-  const buffer = base58.decode(fingerprint.substr(1));
-  // assume buffer is: 0xed 0x01 <public key bytes>
-  return base58.encode(buffer.slice(2));
-}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "bedrock-jsonld-document-loader": "^1.0.1",
     "bedrock-mongodb": "^6.0.2",
     "bedrock-package-manager": "^1.0.0",
-    "bedrock-security-context": "^3.0.0",
     "bedrock-zcap-storage": "^1.0.0"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-kms",
   "dependencies": {
-    "bs58": "^4.0.1",
     "did-method-key": "^0.5.0",
     "jsonld-signatures": "^5.0.0",
     "webkms-switch": "^1.3.0"

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "bedrock-did-context": "^1.0.0",
     "bedrock-jsonld-document-loader": "^1.0.1",
     "bedrock-mongodb": "^6.0.2",
-    "bedrock-package-manager": "^1.0.0",
-    "bedrock-zcap-storage": "^1.0.0"
+    "bedrock-package-manager": "^1.0.0"
   },
   "directories": {
     "lib": "./lib"


### PR DESCRIPTION
The helper here was replace a short while ago by did-key stuff.

Looking at cleaning up peer dep warnings in application level code and discovered that neither bedrock-security-context or bedrock-zcap-storage are `required` here.