### PR TITLE
Use mongo 3.5 api.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,10 +19,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Start MongoDB v${{ matrix.mongodb-version}}
-      uses: supercharge/mongodb-github-action@1.3.0
-      with:
-        mongodb-version: ${{ matrix.mongodb-version }}
     - run: |
         cd test
         npm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mongodb:
-        image: mongo:3.6
+        image: mongo:4.2
         ports:
           - 27017:27017
     strategy:
@@ -19,6 +19,10 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Start MongoDB v${{ matrix.mongodb-version}}
+      uses: supercharge/mongodb-github-action@1.3.0
+      with:
+        mongodb-version: ${{ matrix.mongodb-version }}
     - run: |
         cd test
         npm install
@@ -47,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mongodb:
-        image: mongo:3.6
+        image: mongo:4.2
         ports:
           - 27017:27017
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # bedrock-kms ChangeLog
 
-## 2.2.0 -
+## 3.0.0 -
 
 ### Changed
+- **BREAKING**: Upgraded to `bedrock-mongodb` ^7.0.0.
 - Mongodb `update` is now `updateOne`.
 - Mongodb `find` no longer accepts fields.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # bedrock-kms ChangeLog
 
+## 2.2.0 -
+
+### Changed
+- Mongodb `update` is now `updateOne`.
+- Mongodb `find` no longer accepts fields.
+
+### Added
+- `find` now throws in both options.projection and fields are set.
+
 ## 2.1.0 - 2020-05-15
 
 ### Changed

--- a/lib/MongoDBKeyDescriptionStorage.js
+++ b/lib/MongoDBKeyDescriptionStorage.js
@@ -43,7 +43,7 @@ module.exports = class MongoDBKeyDescriptionStorage
     // used in `.get()`
     delete key.controller;
     try {
-      const result = await database.collections.kms.insert(
+      const result = await database.collections.kms.insertOne(
         record, database.writeOptions);
       return result.ops[0];
     } catch(e) {

--- a/lib/keystores.js
+++ b/lib/keystores.js
@@ -114,9 +114,9 @@ api.find = async ({
   query.controller = database.hash(controller);
   // FIXME remove options.fields from all libraries that call on bedrock-kms
   // instead use options.projection
-  if(fields) {
-    logger.info('The parameter fields in method find is being ' +
-      'deprecated please use options.projection instead');
+  if(fields && options.projection) {
+    throw new TypeError(
+      '"fields" or "options.projection" must be given, not both.');
   }
   options.projection = options.projection || fields;
   return database.collections.kmsKeystore.find(query, options).toArray();

--- a/lib/keystores.js
+++ b/lib/keystores.js
@@ -7,7 +7,6 @@ const assert = require('assert-plus');
 const bedrock = require('bedrock');
 const database = require('bedrock-mongodb');
 const {promisify} = require('util');
-const logger = require('./logger');
 const {BedrockError} = bedrock.util;
 
 // load config defaults
@@ -101,23 +100,24 @@ api.insert = async ({config} = {}) => {
  * @param {string} options.controller - The controller for the keystores to
  *   retrieve.
  * @param {Object} [options.query={}] - The query to use.
- * @param {Object} [options.fields={}] - The fields to include or exclude.
+ * @param {Object} [options.fields=undefined] - The fields to include or
+ *   exclude.
  * @param {Object} [options.options={}] - The query options (eg: 'sort').
  *
  * @return {Promise<Array>} resolves to the records that matched the query.
  */
 api.find = async ({
-  controller, query = {}, fields = {}, options = {}
+  controller, query = {}, fields, options = {}
 } = {}) => {
   assert.string(controller, 'options.controller');
   // force controller ID
   query.controller = database.hash(controller);
-  // FIXME remove options.fields from all libraries that call on bedrock-kms
-  // instead use options.projection
   if(fields && options.projection) {
     throw new TypeError(
       '"fields" or "options.projection" must be given, not both.');
   }
+  // FIXME remove options.fields from all libraries that call on bedrock-kms
+  // instead use options.projection
   options.projection = options.projection || fields;
   return database.collections.kmsKeystore.find(query, options).toArray();
 };

--- a/lib/keystores.js
+++ b/lib/keystores.js
@@ -7,6 +7,7 @@ const assert = require('assert-plus');
 const bedrock = require('bedrock');
 const database = require('bedrock-mongodb');
 const {promisify} = require('util');
+const logger = require('./logger');
 const {BedrockError} = bedrock.util;
 
 // load config defaults
@@ -77,7 +78,7 @@ api.insert = async ({config} = {}) => {
     config
   };
   try {
-    const result = await database.collections.kmsKeystore.insert(
+    const result = await database.collections.kmsKeystore.insertOne(
       record, database.writeOptions);
     return result.ops[0];
   } catch(e) {
@@ -111,8 +112,14 @@ api.find = async ({
   assert.string(controller, 'options.controller');
   // force controller ID
   query.controller = database.hash(controller);
-  return database.collections.kmsKeystore.find(
-    query, fields, options).toArray();
+  // FIXME remove options.fields from all libraries that call on bedrock-kms
+  // instead use options.projection
+  if(fields) {
+    logger.info('The parameter fields in method find is being ' +
+      'deprecated please use options.projection instead');
+  }
+  options.projection = options.projection || fields;
+  return database.collections.kmsKeystore.find(query, options).toArray();
 };
 
 /**
@@ -159,7 +166,7 @@ api.update = async ({config} = {}) => {
   // insert the configuration and get the updated record
   const now = Date.now();
 
-  const result = await database.collections.kmsKeystore.update({
+  const result = await database.collections.kmsKeystore.updateOne({
     id: database.hash(config.id),
     'config.sequence': config.sequence - 1
   }, {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "bedrock-did-context": "^1.0.0",
     "bedrock-veres-one-context": "^10.0.0",
     "bedrock-jsonld-document-loader": "^1.0.1",
-    "bedrock-mongodb": "^6.0.2",
+    "bedrock-mongodb": "^7.0.0",
     "bedrock-package-manager": "^1.0.1"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lib": "./lib"
   },
   "devDependencies": {
-    "eslint": "^6.8.0",
+    "eslint": "^7.2.0",
     "eslint-config-digitalbazaar": "^2.3.0"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -18,7 +18,7 @@
     "bedrock-ledger-context": "^14.0.0",
     "bedrock-package-manager": "^1.0.1",
     "bedrock-security-context": "^3.0.0",
-    "bedrock-ssm-mongodb": "digitalbazaar/bedrock-ssm-mongodb#mongo-version-3",
+    "bedrock-ssm-mongodb": "^3.0.0",
     "bedrock-veres-one-context": "^10.0.0",
     "bedrock-test": "^5.2.0",
     "cross-env": "^7.0.2",

--- a/test/package.json
+++ b/test/package.json
@@ -14,7 +14,7 @@
     "bedrock-did-context": "^1.0.0",
     "bedrock-jsonld-document-loader": "^1.0.1",
     "bedrock-kms": "file:..",
-    "bedrock-mongodb": "^6.0.2",
+    "bedrock-mongodb": "digitalbazaar/bedrock-mongodb#driver3",
     "bedrock-ledger-context": "^14.0.0",
     "bedrock-package-manager": "^1.0.1",
     "bedrock-security-context": "^3.0.0",

--- a/test/package.json
+++ b/test/package.json
@@ -14,7 +14,7 @@
     "bedrock-did-context": "^1.0.0",
     "bedrock-jsonld-document-loader": "^1.0.1",
     "bedrock-kms": "file:..",
-    "bedrock-mongodb": "digitalbazaar/bedrock-mongodb#driver3",
+    "bedrock-mongodb": "^7.0.0",
     "bedrock-ledger-context": "^14.0.0",
     "bedrock-package-manager": "^1.0.1",
     "bedrock-security-context": "^3.0.0",

--- a/test/package.json
+++ b/test/package.json
@@ -18,7 +18,7 @@
     "bedrock-ledger-context": "^14.0.0",
     "bedrock-package-manager": "^1.0.1",
     "bedrock-security-context": "^3.0.0",
-    "bedrock-ssm-mongodb": "^2.0.1",
+    "bedrock-ssm-mongodb": "digitalbazaar/bedrock-ssm-mongodb#mongo-version-3",
     "bedrock-veres-one-context": "^10.0.0",
     "bedrock-test": "^5.2.0",
     "cross-env": "^7.0.2",


### PR DESCRIPTION
draft PR await next release of bedrock-mongodb with mongo 3.5 driver.
This should work with the updated driver. This is a breaking release.

This requires `bedrock-ssm-mongodb`'s next release: https://github.com/digitalbazaar/bedrock-ssm-mongodb/pull/6

- Is a major release 3.0
- [x] contains an updated CHANGELOG.
- [x] Requires `bedrock-ssm-mongodb` `^3.0.0`.
- [x] tests should pass once version 3 of bedrock-ssm-mongodb is released.