### PR TITLE
Expand keystore validator

### DIFF
--- a/lib/keystores.js
+++ b/lib/keystores.js
@@ -136,7 +136,8 @@ api.update = async ({config} = {}) => {
   assert.number(config.sequence, 'config.sequence');
   assert.optionalString(config.referenceId, 'config.referenceId');
 
-  const validProps = new Set(['id', 'controller', 'sequence', 'referenceId']);
+  const validProps = new Set([
+    'id', 'controller', 'sequence', 'referenceId', 'invoker', 'delegator']);
   for(const key in config) {
     if(!validProps.has(key)) {
       throw new BedrockError(

--- a/lib/keystores.js
+++ b/lib/keystores.js
@@ -135,7 +135,7 @@ api.update = async ({config} = {}) => {
   assert.string(config.controller, 'config.controller');
   assert.number(config.sequence, 'config.sequence');
   assert.optionalString(config.referenceId, 'config.referenceId');
-
+  // FIXME shouldn't this be a bedrock-kms-http validator?
   const validProps = new Set([
     'id', 'controller', 'sequence', 'referenceId', 'invoker', 'delegator']);
   for(const key in config) {


### PR DESCRIPTION
This expands the keystore validator by 2 more terms: `invoker` and `delegator`.

Also, shouldn't this be a json-schema validator in `bedrock-kms-http`?