### PR TITLE
Issue 29 upgrade mongo 7.1.0

### DIFF
--- a/lib/MongoDBKeyDescriptionStorage.js
+++ b/lib/MongoDBKeyDescriptionStorage.js
@@ -89,7 +89,7 @@ module.exports = class MongoDBKeyDescriptionStorage
       keystores.get({id: keystoreId}),
       database.collections.kms.findOne(
         {id: database.hash(id)},
-        {_id: 0, key: 1, meta: 1})
+        {projection: {_id: 0, key: 1, meta: 1}})
     ]);
     if(!record || !config) {
       throw new BedrockError(

--- a/lib/keystores.js
+++ b/lib/keystores.js
@@ -206,7 +206,7 @@ api.get = async ({id} = {}) => {
 
   const record = await database.collections.kmsKeystore.findOne(
     {id: database.hash(id)},
-    {_id: 0, config: 1, meta: 1});
+    {projection: {_id: 0, config: 1, meta: 1}});
   if(!record) {
     throw new BedrockError(
       'Keystore configuration not found.',

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "bedrock-did-context": "^1.0.0",
     "bedrock-veres-one-context": "^10.0.0",
     "bedrock-jsonld-document-loader": "^1.0.1",
-    "bedrock-mongodb": "^7.0.0",
+    "bedrock-mongodb": "^7.1.0",
     "bedrock-package-manager": "^1.0.1"
   },
   "directories": {

--- a/test/mocha/11-keystores-get-api.js
+++ b/test/mocha/11-keystores-get-api.js
@@ -56,13 +56,13 @@ describe('keystores APIs', () => {
       assertNoError(err);
       should.exist(result);
       result.should.be.an('object');
-      result.should.have.property('meta');
+      // ensure the projection only return meta & config
+      Object.keys(result).should.deep.equal(['meta', 'config']);
       result.meta.should.have.property('created');
       result.meta.should.have.property('updated');
-      result.should.have.property('config');
       result.config.should.eql(mockConfig);
     });
-    it('successfully gets a keystore', async () => {
+    it('unsuccessfully gets a keystore', async () => {
       const unknownId = 'bd9a90e3-2989-4d40-81c6-94ad0c98c56c';
       let err;
       let result;

--- a/test/package.json
+++ b/test/package.json
@@ -14,7 +14,7 @@
     "bedrock-did-context": "^1.0.0",
     "bedrock-jsonld-document-loader": "^1.0.1",
     "bedrock-kms": "file:..",
-    "bedrock-mongodb": "^7.0.0",
+    "bedrock-mongodb": "^7.1.0",
     "bedrock-ledger-context": "^14.0.0",
     "bedrock-package-manager": "^1.0.1",
     "bedrock-security-context": "^3.0.0",


### PR DESCRIPTION
- [x] Upgrades to `bedrock-mongodb: 7.1.0`
- [x] fixes findOne projections
- [x] check `find` call
- [x] check updateOne against latest api
- [x] check insertOne against latest api

Addresses this issue:

https://github.com/digitalbazaar/bedrock-kms/issues/29

Overall this module is fine.