### PR TITLE
Add request protection

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,8 @@ didIo.use('v1', require('did-veres-one').driver({mode: 'test'}));
 // load config defaults
 require('./config');
 
+const {util: {BedrockError}} = bedrock;
+
 bedrock.events.on('bedrock.init', async () => {
   // ensure only one host is configured
   const cfg = bedrock.config.kms;
@@ -107,3 +109,50 @@ exports.defaultDocumentLoader = defaultDocumentLoader;
 
 // expose for testing purposes
 exports._caches = require('./caches');
+
+/**
+ * Takes in a request to a kms system from a proxy and validates it.
+ *
+ * @param {object} options - Options to use.
+ * @param {Map<string, Array<string>>} options.allowedHosts - A Map
+ *   with a host and an optional Array of allowed ips.
+ * @param {string} options.host - An URL's host.
+ * @param {string} options.ip - An ip for the request.
+ *
+ * @throws {BedrockError} - A NotAllowedError if ip rules are broken.
+ *
+ * @returns {object} An object with the verify result and any errors.
+ */
+exports.validateRequest = ({allowedHosts, host, ip}) => {
+  let verified = false;
+  for(const [allowedHost, ips = []] of allowedHosts) {
+    // if we already found a valid host/ip entry stop
+    if(verified) {
+      break;
+    }
+    // if the host does not match the entry go to the next entry
+    if(host !== allowedHost) {
+      continue;
+    }
+    // if the entry matches the host, but there are no ip rules
+    // then verify and stop
+    if(!ips || ips.length === 0) {
+      verified = true;
+      break;
+    }
+    // if there are ip rules use them to set verified
+    verified = ips.includes(ip);
+    if(!verified) {
+      throw new BedrockError('Permission denied. Expected an allowed IP but ' +
+        `received "${ip}".`, 'NotAllowedError', {
+        httpStatusCode: 400,
+        public: true,
+        ip,
+        ips,
+        host,
+        allowedHost
+      });
+    }
+  }
+  return {verified};
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,11 @@ bedrock.events.on('bedrock.init', async () => {
     if(Array.isArray(cfg.allowedHosts)) {
       cfg.allowedHost = cfg.allowedHosts[0];
     } else if(cfg.allowedHosts instanceof Map) {
-      cfg.allowedHost = cfg.allowedHosts.entries().next().value[0];
+      const {value: firstEntry} = cfg.allowedHosts.entries().next();
+      if(firstEntry) {
+        // the first value should be the key which is the host
+        cfg.allowedHost = firstEntry[0];
+      }
     } else {
       cfg.allowedHost = cfg.allowedHosts;
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,8 @@ bedrock.events.on('bedrock.init', async () => {
   if(!cfg.allowedHost && cfg.allowedHosts) {
     if(Array.isArray(cfg.allowedHosts)) {
       cfg.allowedHost = cfg.allowedHosts[0];
+    } else if(cfg.allowedHosts instanceof Map) {
+      cfg.allowedHost = cfg.allowedHosts.entries().next().value[0];
     } else {
       cfg.allowedHost = cfg.allowedHosts;
     }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "did-veres-one": "^12.1.1",
     "jsonld-signatures": "^5.0.1",
     "lru-cache": "^6.0.0",
-    "webkms-switch": "^2.0.0"
+    "webkms-switch": "github:digitalbazaar/web-kms-switch#add-request-protection"
   },
   "peerDependencies": {
     "bedrock": "^3.1.0",


### PR DESCRIPTION
Part of a ring of PRs:
[bedrock-kms-http](https://github.com/digitalbazaar/bedrock-kms-http/pull/46)
[webkms-switch](https://github.com/digitalbazaar/webkms-switch/pull/7)

These PRs change `bedrock.config.kms.allowedHosts` to a map and allow restricting kms resources by host and ip.