### PR TITLE
Fix partialFilterExpression on kmsKeystore collection

### DIFF
--- a/lib/keystores.js
+++ b/lib/keystores.js
@@ -36,7 +36,7 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
     fields: {controller: 1, 'config.referenceId': 1},
     options: {
       partialFilterExpression: {
-        'config.referenceId': true
+        'config.referenceId': {$exists: true}
       },
       unique: true,
       background: false

--- a/test/mocha/10-keystores-insert-api.js
+++ b/test/mocha/10-keystores-insert-api.js
@@ -184,7 +184,7 @@ describe('keystores APIs', () => {
       result.should.have.property('config');
       result.config.should.eql(config);
     });
-    it('throws on a duplicate keystore config', async () => {
+    it('throws DuplicateError on duplicate keystore config', async () => {
       let err;
       let result;
       const config = {
@@ -208,6 +208,43 @@ describe('keystores APIs', () => {
         err = e;
       }
       should.exist(err);
+      err.name.should.equal('DuplicateError');
     });
+    it('throws DuplicateError on config with same controller and referenceId',
+      async () => {
+        // configs have unique IDs, but the same controller and referenceId
+        let err;
+        let result;
+        const keystoreConfig1 = {
+          id: 'https://example.com/keystores/fbea027c',
+          controller: 'bar',
+          referenceId: 'urn:uuid:72b89236-7bb7-4d00-8930-9c74c4a7a4a8',
+          sequence: 0,
+        };
+        try {
+          result = await keystores.insert({config: keystoreConfig1});
+        } catch(e) {
+          err = e;
+        }
+        assertNoError(err);
+        should.exist(result);
+
+        const keystoreConfig2 = {
+          id: 'https://example.com/keystores/4f398f8f',
+          controller: 'bar',
+          referenceId: 'urn:uuid:72b89236-7bb7-4d00-8930-9c74c4a7a4a8',
+          sequence: 0,
+        };
+
+        result = undefined;
+        err = undefined;
+        try {
+          result = await keystores.insert({config: keystoreConfig2});
+        } catch(e) {
+          err = e;
+        }
+        should.exist(err);
+        err.name.should.equal('DuplicateError');
+      });
   }); // end insert API
 }); // end keystore APIs


### PR DESCRIPTION
There will need to be consideration and conversation about how best to release and deploy this.  I'm not sure how widely used `referenceId` is outside the `bedrock-profile` stack.  Minor changes to `bedrock-profile` will be required in response to this because a `ProfileAgent` temporarily creates a duplicate keystore (previously undetected) for a profile before changing the controller on the keystore to the profile ID.

The test suite lacked a test for this partial index.

A quick look over other usage of `partialFilterExpression` indicates that it is being misconfigured in some other places as well:
https://github.com/search?q=org%3Adigitalbazaar+partialFilterExpression&type=code

I'm creating issues for the ones I see now.