### PR TITLE
Update to use offline-capable did-veres-one driver.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "bedrock": "^4.1.1",
     "bedrock-did-context": "^2.0.0",
-    "bedrock-did-io": "^4.0.0",
+    "bedrock-did-io": "digitalbazaar/bedrock-did-io#offline-veres",
     "bedrock-veres-one-context": "^11.0.0",
     "bedrock-jsonld-document-loader": "^1.0.1",
     "bedrock-mongodb": "^8.2.0",

--- a/test/package.json
+++ b/test/package.json
@@ -17,7 +17,7 @@
     "aes-key-wrapping-2019-context": "^1.0.3",
     "bedrock": "^4.3.0",
     "bedrock-did-context": "^2.0.0",
-    "bedrock-did-io": "^4.0.0",
+    "bedrock-did-io": "digitalbazaar/bedrock-did-io#offline-veres",
     "bedrock-jsonld-document-loader": "^1.0.1",
     "bedrock-kms": "file:..",
     "bedrock-ledger-context": "^18.0.0",


### PR DESCRIPTION
Allows downstream document resolvers to use `driver.getInitial()` instead of `.get()`, which allows fetching unregistered VeresOne DIDs in offline mode.