### PR TITLE
Use mongo driver 4 rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # bedrock-kms ChangeLog
 
+## 12.0.0 -
+
+### Changed
+- **BREAKING**: Use `@bedrock/mongodb: ^11`.
+- **BREAKING**: Use Node Mongodb Driver 4 results API.
+
+### Removed
+- Remove deprecated MongoDB index `background`.
+
 ## 11.0.0 - 2022-06-30
 
 ### Changed

--- a/lib/keystores.js
+++ b/lib/keystores.js
@@ -103,7 +103,7 @@ export async function insert({config} = {}) {
   };
   try {
     const result = await database.collections['kms-keystore'].insertOne(record);
-    return result.ops[0];
+    return record;
   } catch(e) {
     if(!database.isDuplicateError(e)) {
       throw e;
@@ -182,8 +182,8 @@ export async function update({config, explain = false} = {}) {
       'meta.updated': Date.now()
     }
   });
-
-  if(result.result.n === 0) {
+  const n = result.upsertedCount + result.modifiedCount;
+  if(n === 0) {
     // no records changed...
     throw new BedrockError(
       'Could not update keystore configuration. ' +

--- a/lib/keystores.js
+++ b/lib/keystores.js
@@ -102,7 +102,7 @@ export async function insert({config} = {}) {
     config
   };
   try {
-    const result = await database.collections['kms-keystore'].insertOne(record);
+    await database.collections['kms-keystore'].insertOne(record);
     return record;
   } catch(e) {
     if(!database.isDuplicateError(e)) {

--- a/lib/keystores.js
+++ b/lib/keystores.js
@@ -34,12 +34,12 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
     // cover queries keystore by ID
     collection: 'kms-keystore',
     fields: {'config.id': 1},
-    options: {unique: true, background: false}
+    options: {unique: true}
   }, {
     // cover config queries by controller
     collection: 'kms-keystore',
     fields: {'config.controller': 1},
-    options: {unique: false, background: false}
+    options: {unique: false}
   }, {
     // ensure config uniqueness of reference ID per controller
     collection: 'kms-keystore',
@@ -48,8 +48,7 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
       partialFilterExpression: {
         'config.referenceId': {$exists: true}
       },
-      unique: true,
-      background: false
+      unique: true
     }
   }, {
     // cover counting keystores in use by meter ID, if present
@@ -59,7 +58,7 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
       partialFilterExpression: {
         'config.meterId': {$exists: true}
       },
-      unique: false, background: false
+      unique: false
     }
   }]);
 });

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@bedrock/did-context": "^4.0.0",
     "@bedrock/did-io": "^9.0.1",
     "@bedrock/jsonld-document-loader": "^3.0.0",
-    "@bedrock/mongodb": "^10.0.0",
+    "@bedrock/mongodb": "^11.0.0",
     "@bedrock/package-manager": "^3.0.0",
     "@bedrock/security-context": "^7.0.0",
     "@bedrock/veres-one-context": "^14.0.1"

--- a/test/package.json
+++ b/test/package.json
@@ -18,7 +18,7 @@
     "@bedrock/jsonld-document-loader": "^3.0.0",
     "@bedrock/kms": "file:..",
     "@bedrock/ledger-context": "^23.0.0",
-    "@bedrock/mongodb": "^10.0.0",
+    "@bedrock/mongodb": "github:digitalbazaar/bedrock-mongodb#mongo-driver-4-rc-fix-duplicate-error",
     "@bedrock/package-manager": "^3.0.0",
     "@bedrock/security-context": "^7.0.0",
     "@bedrock/ssm-mongodb": "^10.0.0",


### PR DESCRIPTION
Upgrades `@bedrock/mongodb` to a release candidate that uses the version 4 of the node mongodb driver.

- [x] Review code scanning for untested uses of `@bedrock/mongodb`
    - [x] Double check `createIndexes` for deprecated options (no deprecations found)
    - [x] Check `listIndexes` against the mongo driver 3 `indexes` (so far no issues found)
    - [x] Double check `insertOne` usage
    - [x] Ensure that returning `record` matches previous `result.ops[0]` 
- [ ] Retest using mongo server 4, 5, & 6

Awaits:
- [ ] https://github.com/digitalbazaar/bedrock-mongodb/pull/95
- [ ] https://github.com/digitalbazaar/bedrock-mongodb/pull/92